### PR TITLE
Adds support for common tags across resources

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -16,3 +16,10 @@ jobs:
 
   verifyMetadata:
     uses: cloud-native-toolkit/action-workflows/.github/workflows/verify-module-metadata.yaml@v1
+
+  verifyAll:
+    needs: [verify,verifyMetadata]
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: echo "Success"

--- a/README.md
+++ b/README.md
@@ -14,15 +14,14 @@ The module depends on the following software components:
 ### Terraform providers
 
 - IBM Cloud provider >= 1.22.0
-- Helm provider >= 1.1.1 (provided by Terraform)
 
 ## Module dependencies
 
 This module makes use of the output from other modules:
 
-- Resource Group - github.com/cloud-native-toolkit/terraform-ibm-container-platform.git
-- VPC - github.com/cloud-native-toolkit/terraform-ibm-vpc.git
-- Gateway - github.com/cloud-native-toolkit/terraform-ibm-vpc-gateways.git
+- Resource Group - github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group
+- VPC - github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc
+- Gateway - github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc-gateways
 
 ## Example usage
 

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ locals {
   acl_rules = concat(local.default_acl_rules, var.acl_rules)
   vpc_id = data.ibm_is_vpc.vpc.id
   resource_group_id = data.ibm_resource_group.resource_group.id
+  tags              = distinct(concat(var.common_tags, var.tags))
 }
 
 resource null_resource print_names {
@@ -139,7 +140,7 @@ resource ibm_is_subnet vpc_subnets {
   ipv4_cidr_block          = local.ipv4_cidr_block[count.index]
   resource_group           = local.resource_group_id
   network_acl              = var.provision ? ibm_is_network_acl.subnet_acl[0].id : null
-  tags                     = var.tags
+  tags                     = local.tags
 }
 
 data ibm_is_subnet vpc_subnet {

--- a/module.yaml
+++ b/module.yaml
@@ -16,15 +16,15 @@ versions:
   dependencies:
     - id: resource-group
       refs:
-        - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+        - source: github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group
           version: ">= 1.0.0"
     - id: vpc
       refs:
-        - source: github.com/cloud-native-toolkit/terraform-ibm-vpc
+        - source: github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc
           version: ">= 1.0.0"
     - id: gateways
       refs:
-        - source: github.com/cloud-native-toolkit/terraform-ibm-vpc-gateways
+        - source: github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc-gateways
           version: '>= 0.0.0'
       optional: true
   variables:
@@ -48,3 +48,6 @@ versions:
       important: true
     - name: label
       scope: module
+    - name: common_tags
+      scope: global
+      important: true

--- a/test/stages/stage1-gateways.tf
+++ b/test/stages/stage1-gateways.tf
@@ -1,7 +1,9 @@
 module "gateways" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-gateways.git"
+  source = "github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc-gateways.git"
 
   resource_group_id = module.resource_group.id
   region            = var.region
   vpc_name          = module.vpc.name
+  common_tags       = var.common_tags
+  tags              = ["test", "vpc_gateway"]
 }

--- a/test/stages/stage1-resource-group.tf
+++ b/test/stages/stage1-resource-group.tf
@@ -1,5 +1,5 @@
 module "resource_group" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-resource-group.git"
+  source = "github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group.git"
 
   resource_group_name = var.resource_group_name
   ibmcloud_api_key    = var.ibmcloud_api_key

--- a/test/stages/stage1-vpc.tf
+++ b/test/stages/stage1-vpc.tf
@@ -1,9 +1,11 @@
 module "vpc" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc.git"
+  source = "github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc.git"
 
   resource_group_name = module.resource_group.name
   region              = var.region
   name_prefix         = var.name_prefix
   address_prefix_count = var.address_prefix_count
   address_prefixes = jsondecode(var.address_prefixes)
+  common_tags      = var.common_tags
+  tags             = ["test", "vpc"]
 }

--- a/test/stages/stage2-subnets.tf
+++ b/test/stages/stage2-subnets.tf
@@ -34,4 +34,6 @@ module "subnets" {
       source_port_max=22
     }
   }]
+  common_tags      = var.common_tags
+  tags             = ["test", "vpc_subnet"]
 }

--- a/test/stages/variables.tf
+++ b/test/stages/variables.tf
@@ -63,3 +63,7 @@ variable "address_prefixes" {
 variable "address_prefix_count" {
   default = 0
 }
+
+variable "common_tags" {
+  default = ["common1", "test"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,9 @@ variable "tags" {
   default     = []
   description = "Tags that should be added to the instance"
 }
+
+variable "common_tags" {
+  type        = list(string)
+  default     = []
+  description = "Common tags that should be added to the instance"
+}


### PR DESCRIPTION
- Adds common_tags variable set to global scope in the metadata
- Concatenates common_tags and tags values when applied to vpc subnet
- Updates resource_group dependency reference to new location

closes #68

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>